### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/autor.php
+++ b/autor.php
@@ -371,7 +371,7 @@ if (!empty($_GET)) {
                     <td><a href="single.php?_id=<?php echo  $r['_id'];?>"><?php echo  $r['_id'];?></a></td>
                     <td>
                         <?php if (!empty($r["_source"]['doi'])) : ?>
-                            <a href="http://dx.doi.org/<?php echo $r["_source"]['doi'];?>" target="_blank" rel="noopener noreferrer"><?php echo $r["_source"]['doi'];?></a>
+                            <a href="https://doi.org/<?php echo $r["_source"]['doi'];?>" target="_blank" rel="noopener noreferrer"><?php echo $r["_source"]['doi'];?></a>
                         <?php endif; ?>    
                     </td>
                     <td><?php echo $r["_source"]['name'];?></td>

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -438,7 +438,7 @@ class PageSingle
                 '.$description.'                 
                 ';
                 if (!empty($record['doi'])) {            
-                    echo '"sameAs": "http://dx.doi.org/'.$record['doi'].'",';
+                    echo '"sameAs": "https://doi.org/'.$record['doi'].'",';
                 }
                 echo '
                 "about": [
@@ -1331,7 +1331,7 @@ class Record
 
         /* DOI */
         if (!empty($this->doi)) {
-            echo '<p class="uk-text-small uk-margin-remove">DOI: <a href="https://dx.doi.org/'.$this->doi.'" target="_blank" rel="noopener noreferrer">'.$this->doi.'</a></p>';
+            echo '<p class="uk-text-small uk-margin-remove">DOI: <a href="https://doi.org/'.$this->doi.'" target="_blank" rel="noopener noreferrer">'.$this->doi.'</a></p>';
         }
 
         /* Source */
@@ -1369,7 +1369,7 @@ class Record
             }
         }
         if (!empty($this->doi)) {
-            echo '<a class="uk-button uk-button-primary uk-button-small" href="http://dx.doi.org/'.$this->doi.'" target="_blank" rel="noopener noreferrer">DOI</a>';
+            echo '<a class="uk-button uk-button-primary uk-button-small" href="https://doi.org/'.$this->doi.'" target="_blank" rel="noopener noreferrer">DOI</a>';
         }
 
         $sfx_array[] = 'rft.atitle='.$this->name.'';

--- a/pdf.php
+++ b/pdf.php
@@ -51,7 +51,7 @@
         }
     
         if (!empty($cursor["_source"]["doi"])) {
-            $mpdf->WriteHTML('<p>DOI: <a href="https://dx.doi.org/'.$cursor["_source"]["doi"].'">'.$cursor["_source"]["doi"].'</a></p>');
+            $mpdf->WriteHTML('<p>DOI: <a href="https://doi.org/'.$cursor["_source"]["doi"].'">'.$cursor["_source"]["doi"].'</a></p>');
         }
     
         $mpdf->WriteHTML('<h3>Download em: <a href="http://bdpi.usp.br/single.php?_id='.$_GET['_id'].'">http://bdpi.usp.br/single.php?_id='.$_GET['_id'].'</a></h3>');

--- a/single.php
+++ b/single.php
@@ -696,7 +696,7 @@ $cursor = elasticsearch::elastic_get($_GET['_id'], $type, null);
                                             echo ''.$t->gettext("Ano: ").''.$crossRefReference["year"].'<br/>';
                                         }
                                         if (isset($crossRefReference["DOI"])) {
-                                            echo ''.$t->gettext("DOI: ").'<a href="https://dx.doi.org/'.$crossRefReference["DOI"].'" target="_blank" rel="noopener noreferrer">'.$crossRefReference["DOI"].'</a><br/>';
+                                            echo ''.$t->gettext("DOI: ").'<a href="https://doi.org/'.$crossRefReference["DOI"].'" target="_blank" rel="noopener noreferrer">'.$crossRefReference["DOI"].'</a><br/>';
                                         }                                        
                                         //print_r($crossRefReference);
                                     }

--- a/tools/colect_crossref_data.php
+++ b/tools/colect_crossref_data.php
@@ -35,7 +35,7 @@
     {
             global $client; 
             global $index;
-            $url = "https://api.crossref.org/v1/works/http://dx.doi.org/$doi";
+            $url = "https://api.crossref.org/v1/works/https://doi.org/$doi";
             $json = file_get_contents($url);
             $data = json_decode($json, true);
         


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all instances of the old resolver URL.

Cheers!